### PR TITLE
Add elm-test and initial IngredientParser module

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -9,7 +9,8 @@
             "elm/browser": "1.0.1",
             "elm/core": "1.0.2",
             "elm/html": "1.0.0",
-            "elm/json": "1.1.2"
+            "elm/json": "1.1.2",
+            "elm/parser": "1.1.0"
         },
         "indirect": {
             "elm/time": "1.0.0",
@@ -18,7 +19,11 @@
         }
     },
     "test-dependencies": {
-        "direct": {},
-        "indirect": {}
+        "direct": {
+            "elm-explorations/test": "1.2.0"
+        },
+        "indirect": {
+            "elm/random": "1.0.0"
+        }
     }
 }

--- a/src/IngredientParser.elm
+++ b/src/IngredientParser.elm
@@ -5,6 +5,8 @@ import Parser exposing ((|.), (|=), Parser, Step, chompWhile, float, getChompedS
 
 type alias Ingredient =
     { quantity : String
+    , unit : String
+    , desc : String
     }
 
 
@@ -12,13 +14,17 @@ parseLine : Parser Ingredient
 parseLine =
     succeed Ingredient
         |= (getChompedString <| chompWhile Char.isDigit)
+        |. spaces
+        |= (getChompedString <| chompWhile (\c -> c /= ' '))
+        |. spaces
+        |= (getChompedString <| chompWhile (\c -> c /= '\n' || c /= '\u{000D}'))
 
 
 parse : String -> Ingredient
 parse input =
     case Parser.run parseLine input of
         Err err ->
-            Ingredient "A"
+            Ingredient "A" "B" "C"
 
         Ok result ->
             result

--- a/src/IngredientParser.elm
+++ b/src/IngredientParser.elm
@@ -10,10 +10,17 @@ type alias Ingredient =
     }
 
 
+parseUnit : Parser String
+parseUnit =
+    getChompedString <|
+        succeed ()
+            |. chompWhile (\c -> Char.isDigit c || c == '.')
+
+
 parseLine : Parser Ingredient
 parseLine =
     succeed Ingredient
-        |= (getChompedString <| chompWhile Char.isDigit)
+        |= parseUnit
         |. spaces
         |= (getChompedString <| chompWhile (\c -> c /= ' '))
         |. spaces

--- a/src/IngredientParser.elm
+++ b/src/IngredientParser.elm
@@ -39,4 +39,8 @@ parse input =
             Ingredient "A" "B" "C"
 
         Ok result ->
-            result
+            if String.isEmpty result.quantity then
+                Ingredient "1" "EA" input
+
+            else
+                result

--- a/src/IngredientParser.elm
+++ b/src/IngredientParser.elm
@@ -1,0 +1,24 @@
+module IngredientParser exposing (Ingredient, parse)
+
+import Parser exposing ((|.), (|=), Parser, Step, chompWhile, float, getChompedString, loop, spaces, succeed, symbol)
+
+
+type alias Ingredient =
+    { quantity : String
+    }
+
+
+parseLine : Parser Ingredient
+parseLine =
+    succeed Ingredient
+        |= (getChompedString <| chompWhile Char.isDigit)
+
+
+parse : String -> Ingredient
+parse input =
+    case Parser.run parseLine input of
+        Err err ->
+            Ingredient "A"
+
+        Ok result ->
+            result

--- a/src/IngredientParser.elm
+++ b/src/IngredientParser.elm
@@ -17,11 +17,16 @@ parseUnit =
             |. chompWhile (\c -> Char.isDigit c || c == '.' || c == '/')
 
 
+
+-- parseLine : Parser a
+
+
 parseLine : Parser Ingredient
 parseLine =
     succeed Ingredient
         |= parseUnit
-        |. spaces
+        |. chompWhile (\c -> c /= ' ')
+        |. chompWhile (\c -> c == ' ')
         |= (getChompedString <| chompWhile (\c -> c /= ' '))
         |. spaces
         |= (getChompedString <| chompWhile (\c -> c /= '\n' || c /= '\u{000D}'))

--- a/src/IngredientParser.elm
+++ b/src/IngredientParser.elm
@@ -14,7 +14,7 @@ parseUnit : Parser String
 parseUnit =
     getChompedString <|
         succeed ()
-            |. chompWhile (\c -> Char.isDigit c || c == '.')
+            |. chompWhile (\c -> Char.isDigit c || c == '.' || c == '/')
 
 
 parseLine : Parser Ingredient

--- a/tests/IngredientParserTest.elm
+++ b/tests/IngredientParserTest.elm
@@ -8,7 +8,7 @@ import Test exposing (..)
 suite : Test
 suite =
     describe "Parsing"
-        [ test "it works" <|
+        [ test "parses int / unit / description" <|
             \() ->
                 Expect.equal
                     (IngredientParser.parse "12 cup salt and pepper")

--- a/tests/IngredientParserTest.elm
+++ b/tests/IngredientParserTest.elm
@@ -13,6 +13,11 @@ suite =
                 Expect.equal
                     (IngredientParser.parse "12 cup salt and pepper")
                     (Ingredient "12" "cup" "salt and pepper")
+        , test "parse with float quantity" <|
+            \() ->
+                Expect.equal
+                    (IngredientParser.parse "1.5 packets salt and pepper")
+                    (Ingredient "1.5" "packets" "salt and pepper")
         , todo "parse with rational number"
         , todo "parse without quantity"
         ]

--- a/tests/IngredientParserTest.elm
+++ b/tests/IngredientParserTest.elm
@@ -1,0 +1,18 @@
+module IngredientParserTest exposing (suite)
+
+import Expect exposing (Expectation)
+import IngredientParser exposing (..)
+import Test exposing (..)
+
+
+suite : Test
+suite =
+    describe "Parsing"
+        [ test "it works" <|
+            \() ->
+                Expect.equal
+                    (IngredientParser.parse "12 cup salt and pepper")
+                    (Ingredient "12" "cup" "salt and pepper")
+        , todo "parse with rational number"
+        , todo "parse without quantity"
+        ]

--- a/tests/IngredientParserTest.elm
+++ b/tests/IngredientParserTest.elm
@@ -18,6 +18,10 @@ suite =
                 Expect.equal
                     (IngredientParser.parse "1.5 packets salt and pepper")
                     (Ingredient "1.5" "packets" "salt and pepper")
-        , todo "parse with rational number"
+        , test "parse with rational quantity" <|
+            \() ->
+                Expect.equal
+                    (IngredientParser.parse "2/3 cup concrete aggregate")
+                    (Ingredient "2/3" "cup" "concrete aggregate")
         , todo "parse without quantity"
         ]

--- a/tests/IngredientParserTest.elm
+++ b/tests/IngredientParserTest.elm
@@ -23,5 +23,14 @@ suite =
                 Expect.equal
                     (IngredientParser.parse "2/3 cup concrete aggregate")
                     (Ingredient "2/3" "cup" "concrete aggregate")
-        , todo "parse without quantity"
+        , test "parse with bad quantity" <|
+            \() ->
+                Expect.equal
+                    (IngredientParser.parse "2/3e12 cup concrete aggregate")
+                    (Ingredient "2/3" "cup" "concrete aggregate")
+        , test "parse with no quantity" <|
+            \() ->
+                Expect.equal
+                    (IngredientParser.parse "season beef overnight")
+                    (Ingredient "1" "EA" "season beef overnight")
         ]


### PR DESCRIPTION
Use elm/parser library to create ingredient parser from user submitted text

- [x] Parse with float quantity
- [x] Parse rational quantity
- [ ] Parse with no quantity, defaulting to 1 EA